### PR TITLE
Add Weekday to Mensa Message

### DIFF
--- a/cogs/mensaService.py
+++ b/cogs/mensaService.py
@@ -31,7 +31,7 @@ class MensaService(commands.Cog):
         meals: list[Meal] = mensaUtils.get_mensa_plan(current_date)
 
         await channel.send(
-            f"## Mensaplan vom {current_date.strftime('%d.%m.%Y')}",
+            f"## Mensaplan vom {current_date.strftime('%d.%m.%Y')} \n ({current_date.strftime('%A')})",
             embeds=[meal.create_embed() for meal in meals])
 
     @commands.slash_command(
@@ -53,7 +53,7 @@ class MensaService(commands.Cog):
 
         meals: list[Meal] = mensaUtils.get_mensa_plan(current_date)
         await ctx.respond(
-            f"## Mensaplan vom {current_date.strftime('%d.%m.%Y')}",
+            f"## Mensaplan vom {current_date.strftime('%d.%m.%Y')} \n ({current_date.strftime('%A')})",
             embeds=[meal.create_embed() for meal in meals],
             view=MensaView(current_date))
 


### PR DESCRIPTION
added current_date.strftime('%A') to mensa message in order to display the weekday
helps with orientation